### PR TITLE
feat: add wildcard pattern support for route matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ See [Releases](https://github.com/voronelf/httpfake/releases) for detailed histo
 
 See [godoc reference](https://godoc.org/github.com/voronelf/httpfake) for detailed API documentation.
 
+## Wildcard Routes
+
+Httpfake supports wildcard patterns in route paths using the `*` character.
+This allows matching dynamic path segments without specifying exact values.
+
+```go
+// Match any user ID in the path
+fakeService.NewHandler().
+  Get("/users/*/").
+  Reply(200).
+  BodyString(`[{"username": "dreamer"}]`)
+
+// This will match:
+// - GET /users/1/
+// - GET /users/123/
+// - GET /users/any-value/
+```
+
+Wildcard patterns are supported for all HTTP methods: `Get`, `Post`, `Put`, `Patch`, `Delete`, `Head`.
+
 ## Assertions
 
 There are built-in methods you can use to make assertions about requests to your HTTP handlers. The currently

--- a/functional_tests/wildcard_delete_test.go
+++ b/functional_tests/wildcard_delete_test.go
@@ -1,0 +1,46 @@
+// nolint dupl
+package functional_tests
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/voronelf/httpfake"
+)
+
+// TestWildcardDelete tests a fake server handling a DELETE request with path parameter and using wildcard in path
+func TestWildcardDelete(t *testing.T) {
+	fakeService := httpfake.New()
+	defer fakeService.Server.Close()
+
+	// register a handler for our fake service
+	fakeService.NewHandler().
+		Delete("/users/*/").
+		Reply(200)
+
+	req, err := http.NewRequest("DELETE", fakeService.ResolveURL("/users/1/"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close() // nolint errcheck
+
+	// Check the status code is what we expect
+	if status := res.StatusCode; status != 200 {
+		t.Errorf("request returned wrong status code: got %v want %v",
+			status, 200)
+	}
+
+	// Check the response body is what we expect
+	expected := ""
+	body, _ := ioutil.ReadAll(res.Body)
+	if bodyString := string(body); bodyString != expected {
+		t.Errorf("request returned unexpected body: got %v want %v",
+			bodyString, expected)
+	}
+}

--- a/functional_tests/wildcard_get_test.go
+++ b/functional_tests/wildcard_get_test.go
@@ -1,0 +1,42 @@
+// nolint dupl
+package functional_tests
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/voronelf/httpfake"
+)
+
+// TestWildcardGet tests a fake server handling a GET request with path parameter and using wildcard in path
+func TestWildcardGet(t *testing.T) {
+	fakeService := httpfake.New()
+	defer fakeService.Server.Close()
+
+	// register a handler for our fake service
+	fakeService.NewHandler().
+		Get("/users/*/").
+		Reply(200).
+		BodyString(`[{"username": "dreamer"}]`)
+
+	res, err := http.Get(fakeService.ResolveURL("/users/1/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close() // nolint errcheck
+
+	// Check the status code is what we expect
+	if status := res.StatusCode; status != 200 {
+		t.Errorf("request returned wrong status code: got %v want %v",
+			status, 200)
+	}
+
+	// Check the response body is what we expect
+	expected := `[{"username": "dreamer"}]`
+	body, _ := ioutil.ReadAll(res.Body)
+	if bodyString := string(body); bodyString != expected {
+		t.Errorf("request returned unexpected body: got %v want %v",
+			bodyString, expected)
+	}
+}

--- a/functional_tests/wildcard_patch_test.go
+++ b/functional_tests/wildcard_patch_test.go
@@ -1,0 +1,49 @@
+// nolint dupl
+package functional_tests
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/voronelf/httpfake"
+)
+
+// TestWildcardPatch tests a fake server handling a PATCH request with path parameter and using wildcard in path
+func TestWildcardPatch(t *testing.T) {
+	fakeService := httpfake.New()
+	defer fakeService.Server.Close()
+
+	// register a handler for our fake service
+	fakeService.NewHandler().
+		Patch("/users/*/").
+		Reply(200).
+		BodyString(`{"id": 1,"username": "dreamer"}`)
+
+	sendBody := bytes.NewBuffer([]byte(`{"username": "dreamer"}`))
+	req, err := http.NewRequest("PATCH", fakeService.ResolveURL("/users/1/"), sendBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close() // nolint errcheck
+
+	// Check the status code is what we expect
+	if status := res.StatusCode; status != 200 {
+		t.Errorf("request returned wrong status code: got %v want %v",
+			status, 200)
+	}
+
+	// Check the response body is what we expect
+	expected := `{"id": 1,"username": "dreamer"}`
+	body, _ := ioutil.ReadAll(res.Body)
+	if bodyString := string(body); bodyString != expected {
+		t.Errorf("request returned unexpected body: got %v want %v",
+			bodyString, expected)
+	}
+}

--- a/functional_tests/wildcard_post_test.go
+++ b/functional_tests/wildcard_post_test.go
@@ -1,0 +1,44 @@
+// nolint dupl
+package functional_tests
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/voronelf/httpfake"
+)
+
+// TestWildcardPost tests a fake server handling a POST request with path parameter and using wildcard in path
+func TestWildcardPost(t *testing.T) {
+	fakeService := httpfake.New()
+	defer fakeService.Server.Close()
+
+	// register a handler for our fake service
+	fakeService.NewHandler().
+		Post("/users/*/").
+		Reply(201).
+		BodyString(`{"id": 1, "username": "dreamer"}`)
+
+	sendBody := bytes.NewBuffer([]byte(`{"username": "dreamer"}`))
+	res, err := http.Post(fakeService.ResolveURL("/users/1/"), "application/json", sendBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close() // nolint errcheck
+
+	// Check the status code is what we expect
+	if status := res.StatusCode; status != 201 {
+		t.Errorf("request returned wrong status code: got %v want %v",
+			status, 201)
+	}
+
+	// Check the response body is what we expect
+	expected := `{"id": 1, "username": "dreamer"}`
+	body, _ := ioutil.ReadAll(res.Body)
+	if bodyString := string(body); bodyString != expected {
+		t.Errorf("request returned unexpected body: got %v want %v",
+			bodyString, expected)
+	}
+}

--- a/functional_tests/wildcard_put_test.go
+++ b/functional_tests/wildcard_put_test.go
@@ -1,0 +1,49 @@
+// nolint dupl
+package functional_tests
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/voronelf/httpfake"
+)
+
+// TestWildcardPut tests a fake server handling a PUT request with path parameter and using wildcard in path
+func TestWildcardPut(t *testing.T) {
+	fakeService := httpfake.New()
+	defer fakeService.Server.Close()
+
+	// register a handler for our fake service
+	fakeService.NewHandler().
+		Put("/users/*/").
+		Reply(200).
+		BodyString(`{"id": 1,"username": "dreamer"}`)
+
+	sendBody := bytes.NewBuffer([]byte(`{"username": "dreamer"}`))
+	req, err := http.NewRequest("PUT", fakeService.ResolveURL("/users/1/"), sendBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close() // nolint errcheck
+
+	// Check the status code is what we expect
+	if status := res.StatusCode; status != 200 {
+		t.Errorf("request returned wrong status code: got %v want %v",
+			status, 200)
+	}
+
+	// Check the response body is what we expect
+	expected := `{"id": 1,"username": "dreamer"}`
+	body, _ := ioutil.ReadAll(res.Body)
+	if bodyString := string(body); bodyString != expected {
+		t.Errorf("request returned unexpected body: got %v want %v",
+			bodyString, expected)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.19
 require github.com/tidwall/gjson v1.17.0
 
 require (
-	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/match v1.1.1
 	github.com/tidwall/pretty v1.2.0 // indirect
 )

--- a/httpfake.go
+++ b/httpfake.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/tidwall/match"
 )
 
 // HTTPFake is the root struct for the fake server
@@ -156,7 +158,7 @@ func (f *HTTPFake) findHandler(r *http.Request) (*Request, error) {
 			continue
 		}
 
-		if rh.URL.String() == url {
+		if match.Match(url, rh.URL.String()) {
 			return rh, nil
 		}
 


### PR DESCRIPTION
- Add github.com/tidwall/match dependency for wildcard pattern matching
- Update findHandler() to use match.Match() instead of exact URL comparison
- Add wildcard tests for all HTTP methods (GET, POST, PUT, PATCH, DELETE)